### PR TITLE
Fix: pin static field declaration order to original `field_idx` to stop `static_values`  misalignment

### DIFF
--- a/src/asc_core/core/dex/dex_manager.py
+++ b/src/asc_core/core/dex/dex_manager.py
@@ -59,6 +59,9 @@ class DexManager:
         dvminterp = DvmInterpreter()
         dvminterp.addHandler(idx_handler)
 
+        # Pin own-field declaration order before any bytecode is rewritten.
+        idx_handler.preregister_own_fields(clazz.fields)
+
         modified_bytecodes = {}
         
         t_setup_end = time.perf_counter()

--- a/src/asc_core/core/dex/dex_remapper.py
+++ b/src/asc_core/core/dex/dex_remapper.py
@@ -202,6 +202,19 @@ class DexIndexMapper:
 
         self._fill_data_types()
 
+        # === CLASS FIELD IDX  ===
+        for field_obj in sorted(self.fields_obj, key=lambda f: f.index):
+            if field_obj.index in self.field_restruct_idx:
+                continue
+            fld_clz_string = field_obj.cls.fullname
+            fld_clz_typeidx = self._append_string_to_types(fld_clz_string)
+            fld_type_string = self._type_to_descriptor(field_obj.type)
+            fld_type_typeidx = self._append_string_to_types(fld_type_string)
+            fld_name_string = field_obj.name
+            fld_name_stridx = self._add_str_restruct(fld_name_string)
+            new_field = [fld_clz_typeidx, fld_type_typeidx, fld_name_stridx]
+            self._add_field_restruct(new_field, field_obj.index)
+
         # === FIELD IDX ===
         for i in range(len(self.mapper["FIELD"])):
             if i in self.mapper["FIELD"]:

--- a/src/asc_core/core/dvm_handlers.py
+++ b/src/asc_core/core/dvm_handlers.py
@@ -45,6 +45,28 @@ class IndexHandler(DvmHandler):
             return new_idx
         return rev[origin_idx]
 
+    def add_index(self, idx_type, origin_idx):
+        """Pin origin_idx to a deterministic new index (idempotent)."""
+        rev = self.reverse_mapper[idx_type]
+        if origin_idx not in rev:
+            fwd = self.mapper[idx_type]
+            new_idx = len(fwd)
+            fwd[new_idx] = origin_idx
+            rev[origin_idx] = new_idx
+        return rev[origin_idx]
+
+    def preregister_own_fields(self, fields):
+        """Pin this class's own declared fields to the leading new field
+        indices, ordered by original field_idx ascending.
+
+        This is the single definition of the field declaration order: it makes
+        bytecode operands (rewritten here), the rebuilt field table
+        (DexIndexMapper), the class_data declaration (DexBuilder) and the
+        static_values encoded_array all follow the same original-index order,
+        so field initializers stay aligned with their fields."""
+        for field_obj in sorted(fields, key=lambda f: f.index):
+            self.add_index("FIELD", field_obj.index)
+
     def getMapper(self):
         return self.mapper
 


### PR DESCRIPTION
## Root Cause: static field initializer misalignment in DEX rebuild

### The DEX invariant that was violated

In a DEX `class_data_item`, the `static_fields` list and the class's `static_values` encoded array are **both ordered by original `field_idx` ascending**. The array has no per-entry field reference — the *i*-th value belongs to the *i*-th static field **by position**. Alignment is therefore purely positional: whatever order you declare the fields in, the values must follow the exact same order.

### How the rebuild broke it

ASC rebuilds a single class into a fresh, minimal DEX. Field indices are reassigned by `IndexHandler.mapIndex`, which hands out new indices **in the order instructions are scanned** (first `sget`/`sput`/`iget` seen wins). This scan order is unrelated to the original declaration order.

Concretely, in `android/content/Context` from `services.jar`:

- The original DEX declares 318 static fields in `field_idx` ascending order, and `static_values` (317 entries) follows that same order. The first field, `ACCESSIBILITY_SERVICE`, is assigned via `sput` inside `<clinit>` and therefore has **no** entry in the array.
- During rebuild, `sLastAutofillId` (original `field_idx` 32320) happens to be scanned first, so it receives new index `0`; `ACCESSIBILITY_SERVICE` (original `field_idx` 32003) receives new index `3`.

Three pieces then disagreed:

1. **New field table** — built in scan order.
2. **class_data field declaration** — `DexBuilder` sorted by the *new* index (`field_restruct_idx`).
3. **`static_values` array** — copied verbatim, still in *original* index order.

Because (2) and (3) used different orderings, the value array was effectively shifted by one slot against the field list:

```
declared[0] = sLastAutofillId          <- value[0] = "accessibility"   (wrong; it is sput-inited)
declared[1] = ACCESSIBILITY_SERVICE    <- value[1] = "account"         (wrong)
declared[2] = ACCOUNT_SERVICE          <- value[2] = "activity"        (wrong)
...
```

Every field displayed the **next** field's initializer. The non-final `sLastAutofillId`, which should have **no** entry in `static_values` at all (it is assigned via `sput` in `<clinit>`), even picked up a string it should never hold — producing the reported output:

```java
private static int sLastAutofillId = accessibility;          // bogus
public static final String ACCESSIBILITY_SERVICE = "account";   // shifted
public static final String ACCOUNT_SERVICE = "activity";        // shifted
public static final String ACTIVITY_SERVICE = "activity_task";  // shifted
```

### Why it was latent

The misalignment only becomes visible when scan order ≠ declaration order **and** the class has enough static fields for the shift to land on a recognizable value. Small classes, or classes whose fields happen to be referenced in declaration order, produce a monotonic mapping and appear fine — which is why it survived until a field-heavy class like `Context` (318 static fields, referenced out of order) exposed it.

### The fix

Make the ordering decision once, at the source:

- `IndexHandler.preregister_own_fields()` pins the class's own fields to new indices `0..n-1` in original `field_idx` ascending order **before** any bytecode is rewritten.
- `DexIndexMapper.handle()` registers those same fields **first** (a contiguous ascending prefix of the new field table), ahead of instruction-referenced and hollower-derived fields.
- `DexBuilder` declares `class_data` fields in the resulting table order, so the verbatim `static_values` array lines up again.

As a side effect, `field_idx_diff` entries stay non-negative, satisfying the uleb128 encoding of `class_data_item`.