### PR TITLE
perf: speed up reference search and getclass on large APKs

### DIFF
--- a/src/asc_client/apk_handler.py
+++ b/src/asc_client/apk_handler.py
@@ -2,12 +2,14 @@ import atexit
 import mmap
 import os
 import struct
+import sys
 import threading
 import time
+import types
 import zlib
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, FIRST_COMPLETED, wait
+from concurrent.futures import ThreadPoolExecutor, FIRST_COMPLETED, wait
 
-from src.asc_client.dex_container import iter_logical_dex_buffers
+from src.asc_client.dex_container import iter_logical_dex_buffers, is_dex041_container
 
 
 _U16 = struct.Struct("<H")
@@ -26,21 +28,51 @@ _WORKER_APK_FP = None
 _WORKER_APK_MM = None
 
 
+def _process_pool_context():
+    """Prefer fork so workers do not have to re-import the whole module graph.
+
+    spawn re-executes the parent's __main__ and re-imports every module a worker
+    touches; measured on the 352MB sample that is 85ms of pool cost versus 19ms for
+    fork. fork is only used when it is safe: never on Windows, and never from a
+    multi-threaded parent (fork() there can deadlock on inherited locks).
+    """
+    if os.name == "nt":
+        return None
+    try:
+        import multiprocessing
+        # decompiler.py stubs optional imports for startup; a stub is not a real
+        # module and would be accepted silently by __getattr__, so verify before
+        # handing it to ProcessPoolExecutor (a bogus context hangs instead of raising)
+        if not isinstance(multiprocessing, types.ModuleType) or not hasattr(multiprocessing, "get_context"):
+            return None
+        if threading.active_count() != 1:
+            return None
+        return multiprocessing.get_context("fork")
+    except (ImportError, ValueError, OSError):
+        return None
+
+
 def _skip_uleb128(buf, off : int) -> int:
     while buf[off] & 0x80:
         off += 1
     return off + 1
 
 
-def _read_string_data_bytes(buf, str_off : int) -> bytes:
+def _read_string_data_bytes(buf, str_off : int, partial = None) -> bytes:
+    # `partial` is a _PartialDex: the dex may only be inflated up to the point
+    # asked for, so a missing terminator means "inflate more", not "malformed".
+    if partial is not None:
+        buf = partial.ensure(str_off + 8)
     ptr = _skip_uleb128(buf, str_off)
     end = buf.find(b"\x00", ptr)
-    if end < 0:
-        raise ValueError("unterminated string_data_item")
+    while end < 0:
+        if partial is None or not partial.grow():
+            raise ValueError("unterminated string_data_item")
+        end = buf.find(b"\x00", ptr)
     return buf[ptr:end]
 
 
-def _find_type_idx(buf, target_bytes : bytes) -> int:
+def _find_type_idx(buf, target_bytes : bytes, partial = None) -> int:
     if len(buf) < 0x70 or buf[:3] != b"dex":
         return -1
 
@@ -64,10 +96,10 @@ def _find_type_idx(buf, target_bytes : bytes) -> int:
         if str_idx >= string_ids_size:
             raise ValueError("bad type_id->string_idx")
         str_off = _U32_FROM(buf, string_ids_off + (str_idx << 2))[0]
-        if str_off >= len(buf):
+        if str_off >= len(buf) and partial is None:
             raise ValueError("bad string_data_off")
 
-        cls_bytes = _read_string_data_bytes(buf, str_off)
+        cls_bytes = _read_string_data_bytes(buf, str_off, partial)
         if cls_bytes == target_bytes:
             return mid
         if cls_bytes < target_bytes:
@@ -103,6 +135,156 @@ def _dex_defines_class(buf, target_bytes : bytes) -> bool:
     if type_idx < 0:
         return False
     return _class_defs_contains_type_idx(buf, type_idx)
+
+
+class _PartialDex:
+    """A Deflate stream that is inflated only as far as the caller asks.
+
+    Deciding whether a dex defines one class needs the header section (string_ids,
+    type_ids, class_defs) plus the handful of string_data_items the type lookup
+    probes. Those string items sit after the header section, so a dex that does not
+    define the class usually never has to be materialised in full.
+    """
+    __slots__ = ("_comp", "_decomp", "_comp_pos", "_buf")
+
+    def __init__(self, comp_view):
+        self._comp = comp_view
+        self._decomp = zlib.decompressobj(-15)
+        self._comp_pos = 0
+        self._buf = bytearray()
+
+    @property
+    def buf(self):
+        return self._buf
+
+    def ensure(self, end : int):
+        # inflate until at least `end` bytes are available, or the stream drains
+        buf = self._buf
+        comp = self._comp
+        while len(buf) < end and self._comp_pos < len(comp):
+            chunk_end = min(self._comp_pos + _DEFLATE_CHUNK, len(comp))
+            buf += self._decomp.decompress(comp[self._comp_pos:chunk_end])
+            self._comp_pos = chunk_end
+        return buf
+
+    def grow(self) -> bool:
+        # force at least one more chunk in; False once the stream is drained
+        if self._comp_pos >= len(self._comp):
+            return False
+        self.ensure(len(self._buf) + _DEFLATE_CHUNK)
+        return True
+
+    def finish(self) -> bytes:
+        self.ensure(1 << 62)
+        return bytes(self._buf)
+
+
+def _open_partial(mm : mmap.mmap, entry):
+    # stored entries cost one memcpy, so only Deflate benefits from the probe
+    name, _uncomp_size, comp_size, local_header_off, comp_method = entry
+    if comp_method != 8 or mm[local_header_off:local_header_off + 4] != _LH_SIG:
+        return None
+    name_len = _U16_FROM(mm, local_header_off + 26)[0]
+    extra_len = _U16_FROM(mm, local_header_off + 28)[0]
+    data_off = local_header_off + 30 + name_len + extra_len
+    return _PartialDex(memoryview(mm)[data_off:data_off + comp_size])
+
+
+def _probe_defines_class(partial : _PartialDex, target_bytes : bytes):
+    """True/False when the partial buffer proves it, None when it cannot decide.
+
+    A False here is sound: every read either completed inside the inflated prefix
+    or the prefix was grown and the step retried, so a negative can only come from
+    a fully evaluated lookup. None means the caller must inflate the dex normally.
+    """
+    buf = partial.ensure(0x70)
+    if len(buf) < 0x70 or buf[:3] != b"dex":
+        return None
+    if is_dex041_container(buf):
+        # a container needs the whole logical-dex walk
+        return None
+    try:
+        string_ids_size = _U32_FROM(buf, 0x38)[0]
+        string_ids_off = _U32_FROM(buf, 0x3C)[0]
+        type_ids_size = _U32_FROM(buf, 0x40)[0]
+        type_ids_off = _U32_FROM(buf, 0x44)[0]
+        class_defs_size = _U32_FROM(buf, 0x60)[0]
+        class_defs_off = _U32_FROM(buf, 0x64)[0]
+    except struct.error:
+        return None
+    # class_defs has to be fully present before it is searched, otherwise a
+    # truncated search could miss the type and turn into a false negative
+    tables_end = max(string_ids_off + string_ids_size * 4,
+                     type_ids_off + type_ids_size * 4,
+                     class_defs_off + class_defs_size * 32)
+    buf = partial.ensure(tables_end)
+    if len(buf) < tables_end:
+        return None
+    type_idx = _find_type_idx(buf, target_bytes, partial)
+    if type_idx < 0:
+        return False
+    return _class_defs_contains_type_idx(partial.buf, type_idx)
+
+
+# DEX header: field_ids (size, off) and method_ids (size, off)
+_MEMBER_ID_TABLES = {"method": (0x58, 0x5C), "field": (0x50, 0x54)}
+
+
+def _probe_has_class_member(partial : _PartialDex, target_bytes : bytes, kind : str):
+    """True/False when the partial dex proves it, None when it cannot decide.
+
+    A findrefs query constrained to a precise class can only match a dex whose
+    <kind>_ids table holds an entry with that class_idx: the locator answers such a
+    query with exactly the ids whose class_idx is the queried type, so a False here
+    means the dex cannot contribute a reference and can be skipped without being
+    inflated in full. Every read grows the partial buffer on demand, so a negative
+    only comes from a fully evaluated lookup.
+    """
+    size_off, off_off = _MEMBER_ID_TABLES[kind]
+    buf = partial.ensure(0x70)
+    if len(buf) < 0x70 or buf[:3] != b"dex":
+        return None
+    if is_dex041_container(buf):
+        return None
+    try:
+        member_size = _U32_FROM(buf, size_off)[0]
+        member_off = _U32_FROM(buf, off_off)[0]
+    except struct.error:
+        return None
+    if member_size == 0:
+        return False
+    type_idx = _find_type_idx(buf, target_bytes, partial)
+    if type_idx < 0:
+        return False
+    end = member_off + member_size * 8
+    buf = partial.ensure(end)
+    if len(buf) < end:
+        return None
+    # each item is (u16 class_idx, u16 proto/type_idx, u32 name_idx): the class_idx
+    # column is every 4th u16, taken in one C-level unpack + strided slice
+    columns = struct.unpack_from("<%dH" % (member_size * 4), buf, member_off)
+    return type_idx in columns[0::4]
+
+
+def _precise_class_target(find : dict, find_type : str):
+    """The dalvik descriptor this query is constrained to, or None.
+
+    Only a precise (non-fuzzy) class gives the sound necessary condition the probe
+    uses; a fuzzy class needs the whole type-descriptor search, which is the
+    locator's own work and is deliberately not duplicated here.
+    """
+    if find_type not in _MEMBER_ID_TABLES:
+        return None
+    spec = find.get(find_type)
+    if not isinstance(spec, dict):
+        return None
+    clz = spec.get("class")
+    if not isinstance(clz, (list, tuple)) or len(clz) != 2 or clz[1] is not True:
+        return None
+    name = clz[0]
+    if not isinstance(name, str) or not name:
+        return None
+    return name.encode()
 
 
 def _find_eocd(mm : mmap.mmap) -> int:
@@ -217,18 +399,22 @@ def _get_worker_apk_mm(apk_path : str):
 
 
 def _inflate_deflate_chunks(comp_view, stop_event):
+    if stop_event is None:
+        # nothing to cancel: hand zlib the whole stream in one call instead of
+        # re-entering it every _DEFLATE_CHUNK bytes (measured ~4% faster per dex)
+        return zlib.decompress(comp_view, -15)
     decomp = zlib.decompressobj(-15)
     out = bytearray()
     pos = 0
     total = len(comp_view)
     while pos < total:
-        if stop_event is not None and stop_event.is_set():
+        if stop_event.is_set():
             return None
         end = min(pos + _DEFLATE_CHUNK, total)
         out.extend(decomp.decompress(comp_view[pos:end]))
         pos = end
     out.extend(decomp.flush())
-    if stop_event is not None and stop_event.is_set():
+    if stop_event.is_set():
         return None
     return bytes(out)
 
@@ -262,18 +448,36 @@ def _findrefs_worker(apk_path : str, entry, find_type : str, find : dict, aggreg
 
     mm = _get_worker_apk_mm(apk_path)
     t0 = time.perf_counter()
-    data = _inflate_dex(mm, entry)
+    data = None
+    skipped = False
+    target = _precise_class_target(find, find_type)
+    if target is not None:
+        partial = _open_partial(mm, entry)
+        if partial is not None:
+            verdict = _probe_has_class_member(partial, target, find_type)
+            if verdict is False:
+                skipped = True
+            elif verdict is True:
+                # the class is referenced here: finish the stream instead of inflating twice
+                data = partial.finish()
+                if entry[1] and len(data) != entry[1]:
+                    raise ValueError(f"size mismatch: expect {entry[1]}, got {len(data)}")
     t1 = time.perf_counter()
+    if skipped:
+        return (entry[0], [], (t1 - t0) * 1000000, 0.0, os.getpid())
+    if data is None:
+        data = _inflate_dex(mm, entry)
+    t2 = time.perf_counter()
     lines = []
     handler = AscHandler(False)
     for dex_name, dex_buf in iter_logical_dex_buffers(entry[0], data):
         lines.extend(handler.findrefs(dex_name, dex_buf, find_type, find, aggregate=aggregate))
-    t2 = time.perf_counter()
+    t3 = time.perf_counter()
     return (
         entry[0],
         lines,
-        (t1 - t0) * 1000000,
-        (t2 - t1) * 1000000,
+        (t2 - t0) * 1000000,
+        (t3 - t2) * 1000000,
         os.getpid(),
     )
 
@@ -285,9 +489,28 @@ def _inflate_and_hit(mm : mmap.mmap, entry, target_bytes : bytes, stop_event : t
         return False, None, None
 
     t0 = time.perf_counter()
-    data = _inflate_dex(mm, entry, stop_event)
+    data = None
+    proven = False
+    partial = _open_partial(mm, entry)
+    if partial is not None and not stop_event.is_set():
+        verdict = _probe_defines_class(partial, target_bytes)
+        if verdict is False:
+            t1 = time.perf_counter()
+            log(
+                f"[APK] [T{tid:04x}] '{name}' probe={(t1 - t0) * 1000000:.2f} us "
+                f"bytes={len(partial.buf)} skip=True"
+            )
+            return False, None, None
+        if verdict is True:
+            # the class is here: finish the stream instead of inflating twice
+            proven = True
+            data = partial.finish()
+            if entry[1] and len(data) != entry[1]:
+                raise ValueError(f"size mismatch: expect {entry[1]}, got {len(data)}")
     if data is None:
-        return False, None, None
+        data = _inflate_dex(mm, entry, stop_event)
+        if data is None:
+            return False, None, None
     t1 = time.perf_counter()
     if stop_event.is_set():
         return False, None, None
@@ -298,7 +521,7 @@ def _inflate_and_hit(mm : mmap.mmap, entry, target_bytes : bytes, stop_event : t
     for dex_name, dex_buf in iter_logical_dex_buffers(name, data):
         if stop_event.is_set():
             return False, None, None
-        if _dex_defines_class(dex_buf, target_bytes):
+        if proven or _dex_defines_class(dex_buf, target_bytes):
             hit = True
             hit_name = dex_name
             hit_data = dex_buf
@@ -385,6 +608,11 @@ class ApkHandler:
             fp.close()
 
     def for_each_findrefs(self, find_type : str, find : dict):
+        # imported before the timer so this once-per-process import is not charged to a
+        # single search; it used to happen at apk_handler import time, and keeping the
+        # getclass path (thread pool only) from paying for it is worth ~8ms of startup
+        from concurrent.futures import ProcessPoolExecutor
+
         t_start = time.perf_counter()
         fp, mm = self._open_apk()
         try:
@@ -397,7 +625,12 @@ class ApkHandler:
         if not entries:
             return
 
-        with ProcessPoolExecutor(max_workers=self.max_workers) as ex:
+        # a forked child inherits whatever is still sitting in the parent's stdio
+        # buffers; flush first so it cannot be emitted a second time on exit
+        sys.stdout.flush()
+        sys.stderr.flush()
+        with ProcessPoolExecutor(max_workers=self.max_workers,
+                                 mp_context=_process_pool_context()) as ex:
             futures = {}
             for entry in entries:
                 fut = ex.submit(_findrefs_worker, self.apk_path, entry, find_type, find)

--- a/src/asc_core/findrefs/scan/code_item_scan.py
+++ b/src/asc_core/findrefs/scan/code_item_scan.py
@@ -120,6 +120,94 @@ OPCODE_PATTERNS = {
 
 _STRUCT_I = struct.Struct('<I')
 _STRUCT_H = struct.Struct('<H')
+_UNPACK_I = _STRUCT_I.unpack_from
+_UNPACK_H = _STRUCT_H.unpack_from
+
+# scan type -> tuple of (opcode byte class, referenced idx width in bytes)
+# the referenced idx always starts two bytes after its opcode byte
+_IDX_GROUPS = {
+        "string" : ((b"[\x1a]", 2), (b"[\x1b]", 4)),
+        "type" : ((b"[\x1c\x1f\x20\x22\x23\x24\x25]", 2),),
+        "field" : ((b"[\x52-\x6d]", 2),),
+        "method" : ((b"[\x6e-\x72\x74-\x78\xfa\xfb]", 2),)
+        }
+
+_ANY_BYTE = b"[\x00-\xff]"
+_CLASS_SPECIAL = frozenset(b"\\]^-[")
+
+
+def _escape_class_byte(value : int) -> bytes:
+    if value in _CLASS_SPECIAL:
+        return b"\\" + bytes([value])
+    return bytes([value])
+
+
+def _byte_class(values) -> bytes:
+    # compact regex character class matching exactly the given byte values
+    values = sorted(set(values))
+    total = len(values)
+    if total == 256:
+        return _ANY_BYTE
+    out = bytearray(b"[")
+    index = 0
+    while index < total:
+        last = index
+        while last + 1 < total and values[last + 1] == values[last] + 1:
+            last += 1
+        if last - index >= 2:
+            out += _escape_class_byte(values[index]) + b"-" + _escape_class_byte(values[last])
+        else:
+            for pos in range(index, last + 1):
+                out += _escape_class_byte(values[pos])
+        index = last + 1
+    out += b"]"
+    return bytes(out)
+
+
+def _build_scan_pattern(opcode_class : bytes, idx_width : int, idxs):
+    # the raw byte scan is a filter: requiring the bytes after the opcode to look
+    # like a referenced idx lets the C regex engine drop almost every false
+    # positive before python sees it. survivors are checked exactly by the caller.
+    lookahead = _ANY_BYTE
+    for shift in range(0, idx_width * 8, 8):
+        lookahead += _byte_class({(idx >> shift) & 0xFF for idx in idxs})
+    return re.compile(opcode_class + b"(?=" + lookahead + b")")
+
+
+def _expand_class(opcode_class : bytes) -> bytes:
+    # b"[\x52-\x6d]" -> the bytes it matches
+    out = bytearray()
+    index = 1
+    end = len(opcode_class) - 1
+    while index < end:
+        if index + 2 < end and opcode_class[index + 1: index + 2] == b"-":
+            out += bytes(range(opcode_class[index], opcode_class[index + 2] + 1))
+            index += 3
+        else:
+            out.append(opcode_class[index])
+            index += 1
+    return bytes(out)
+
+
+_OPCODE_VALUES = {}
+for _groups in _IDX_GROUPS.values():
+    for _class, _width in _groups:
+        _OPCODE_VALUES[_class] = _expand_class(_class)
+
+# CPython compiles a one character class to a literal and scans for it with memchr
+# (measured 0.47 ns/byte); with two or more characters it falls back to the regex VM
+# loop (3.5-6.5 ns/byte), which the translate prefilter below beats outright. So the
+# switch is at two opcodes: the string type's two single-opcode groups keep the regex,
+# every other class (7 type, 11 method, 28 field opcodes) uses the prefilter.
+# Measured on a 3.21MB code region, regex vs prefilter: field 20.0 vs 10.1ms (-50%),
+# method 10.4 vs 8.3ms (-20%), type 20.5 vs 18.1ms (-12%), string 3.0 vs 10.6ms.
+_DENSE_OPCODE_COUNT = 2
+
+
+def _mask_table(values) -> bytes:
+    # 256 entry 0/1 table used by bytes.translate below
+    wanted = set(values)
+    return bytes([1 if byte in wanted else 0 for byte in range(256)])
 
 class CodeItemScanner:
     # when we decide to scan code item, means we already build up the insn locator
@@ -130,46 +218,65 @@ class CodeItemScanner:
         self.buf = self.insn_locator.buf
         self.submem = self.buf[self.off_start: self.off_end]
 
+    # dense opcode classes: a bytes.translate per byte position plus a bigint AND
+    # replaces the regex charset scan. Only the opcode byte and the high idx byte are
+    # masked: the low idx byte class is nearly the whole byte range for a realistic
+    # target set, so masking it removed only a few thousand python iterations while
+    # costing two more full passes over the region (measured -5% to -22% without it).
+    # The exact idx check below still runs on every survivor.
+    def _scan_code_item_dense(self, opcode_values : bytes, idxs : set, mark, matched_offset, mark_idx):
+        off_start = self.off_start
+        raw = self.submem.tobytes()
+        # slicing the raw bytes by the idx offset aligns the low/high masks onto the
+        # opcode position. A slice is a memcpy while the equivalent bigint shift walks
+        # every limb of the region, which measured ~1ms extra per shift on 3.2MB.
+        op_hits = int.from_bytes(raw.translate(_mask_table(opcode_values)), "little")
+        hi_hits = int.from_bytes(raw[3:].translate(_mask_table((idx >> 8) & 0xFF for idx in idxs)), "little")
+        hits = (op_hits & hi_hits).to_bytes(len(raw), "little")
+        submem = self.submem
+        start = hits.find(1)
+        while start != -1:
+            idx = _UNPACK_H(submem, start + 2)[0]
+            if idx in idxs:
+                matched_offset.append(start + off_start)
+                if mark:
+                    mark_idx.append(idx)
+            start = hits.find(1, start + 1)
+
     # if mark is True, record correspond idx for offset
     def _scan_code_item(self, idx_type : str, idxs : set, mark):
         off_start = self.off_start
         submem = self.submem
-        buf_len = len(submem)
         matched_offset = []
         mark_idx = []
         self.mark_idx = mark_idx
 
-        if idx_type == "string":
-            for match in STRINGIDX_OPS.finditer(submem):
-                # buggy, might have oob issue 20260617
-                idx_off = match.start() + 2
-                if match.group() == b'\x1a':
-                    if (idx_off + 2) > buf_len: # bugfix for oob, dont use try-except, bad performance.. 20260729
-                        return matched_offset
-                    idx = _STRUCT_H.unpack_from(submem, idx_off)[0]
-                else: # const-string/jumbo
-                    if (idx_off + 4) > buf_len:
-                        return matched_offset
-                    idx = _STRUCT_I.unpack_from(submem, idx_off)[0]
+        groups = _IDX_GROUPS[idx_type]
+        for opcode_class, idx_width in groups:
+            opcode_values = _OPCODE_VALUES[opcode_class]
+            if idx_width == 2 and len(opcode_values) >= _DENSE_OPCODE_COUNT:
+                self._scan_code_item_dense(opcode_values, idxs, mark, matched_offset, mark_idx)
+                continue
+            pattern = _build_scan_pattern(opcode_class, idx_width, idxs)
+            unpack_from = _UNPACK_I if idx_width == 4 else _UNPACK_H
+            for match in pattern.finditer(submem):
+                start = match.start()
+                # the idx bytes were prefiltered in C, the exact value still
+                # decides whether this opcode really references a target idx
+                idx = unpack_from(submem, start + 2)[0]
                 if idx not in idxs:
                     continue
-                matched_offset.append(idx_off + off_start - 2)
+                matched_offset.append(start + off_start)
                 if mark:
                     mark_idx.append(idx)
-            return matched_offset
-        else:
-            for match in OPCODE_PATTERNS[idx_type].finditer(submem):
-                # buggy, might have oob issue 20260617
-                idx_off = match.start() + 2
-                if (idx_off + 2) > buf_len:
-                    return matched_offset
-                idx = _STRUCT_H.unpack_from(submem, idx_off)[0]
-                if idx not in idxs:
-                    continue
-                matched_offset.append(idx_off + off_start - 2)
-                if mark:
-                    mark_idx.append(idx)
-            return matched_offset
+
+        if len(groups) > 1:
+            # separate scans per idx width break offset order, restore it
+            order = sorted(range(len(matched_offset)), key=matched_offset.__getitem__)
+            matched_offset = [matched_offset[i] for i in order]
+            if mark:
+                mark_idx[:] = [mark_idx[i] for i in order]
+        return matched_offset
 
     # scan struct: {"string": {idx1, idx2...}, "field": ...,}
     # only handle with string idx, field idx, method idx, type idx

--- a/src/asc_core/utils/decompiler.py
+++ b/src/asc_core/utils/decompiler.py
@@ -1,4 +1,7 @@
 import sys
+import types
+
+
 class DummyClass: pass
 class DummyModule:
     __path__ = []
@@ -11,51 +14,71 @@ class DummyModule:
 
 # The dummy import trick bascially gen by LLM 20260607
 
-sys.modules['androguard.core.apk'] = DummyModule()
-sys.modules['networkx'] = DummyModule()
-sys.modules['pygments'] = DummyModule()
-sys.modules['lxml'] = DummyModule()
-sys.modules['asn1crypto'] = DummyModule()
-sys.modules['asn1crypto.x509'] = DummyModule()
-sys.modules['cryptography'] = DummyModule()
-sys.modules['matplotlib'] = DummyModule()
-sys.modules['pydot'] = DummyModule()
-sys.modules['IPython'] = DummyModule()
-sys.modules['colorama'] = DummyModule()
-sys.modules['dateutil'] = DummyModule()
-sys.modules['urllib3'] = DummyModule()
-sys.modules['requests'] = DummyModule()
-sys.modules['idna'] = DummyModule()
-sys.modules['chardet'] = DummyModule()
-sys.modules['certifi'] = DummyModule()
-sys.modules['pkg_resources'] = DummyModule()
+# Install the stubs only for modules that are not already imported. Replacing a real,
+# already imported module (multiprocessing in particular, which concurrent.futures pulls
+# in) breaks every later `import` of it: a stub package has __path__ = [], so
+# `import multiprocessing.connection` raises ModuleNotFoundError and callers that use the
+# placeholder instead fail silently. Dropping a stub that is not needed anyway costs
+# nothing, so this keeps the startup saving without clobbering live modules.
+_STUBBED_MODULES = (
+    'androguard.core.apk',
+    'networkx',
+    'pygments',
+    'lxml',
+    'asn1crypto',
+    'asn1crypto.x509',
+    'cryptography',
+    'matplotlib',
+    'pydot',
+    'IPython',
+    'colorama',
+    'dateutil',
+    'urllib3',
+    'requests',
+    'idna',
+    'chardet',
+    'certifi',
+    'pkg_resources',
+    'loguru',
+    'loguru._logger',
+    'click',
+    'urllib',
+    'urllib.request',
+    'http.client',
+    'email',
+    'email.parser',
+    'email.message',
+    'multiprocessing',
+    'multiprocessing.context',
+    'multiprocessing.reduction',
+    'xml.sax.saxutils',
+    'tempfile',
+    'bz2',
+    'lzma',
+    'shutil',
+    'bisect',
+    'random',
+    'json',
+    'json.scanner',
+    'json.decoder',
+    'json.encoder',
+    'math',
+    'weakref',
+)
+def _install_stub(name):
+    existing = sys.modules.get(name)
+    if existing is not None and not isinstance(existing, DummyModule):
+        # a real module is already loaded: never clobber it with a placeholder
+        return
+    parent = sys.modules.get(name.split('.')[0])
+    if isinstance(parent, types.ModuleType) and not isinstance(parent, DummyModule):
+        # the real parent package is loaded, so this submodule must stay importable
+        return
+    sys.modules[name] = DummyModule()
 
-sys.modules['loguru'] = DummyModule()
-sys.modules['loguru._logger'] = DummyModule()
-sys.modules['click'] = DummyModule()
-sys.modules['urllib'] = DummyModule()
-sys.modules['urllib.request'] = DummyModule()
-sys.modules['http.client'] = DummyModule()
-sys.modules['email'] = DummyModule()
-sys.modules['email.parser'] = DummyModule()
-sys.modules['email.message'] = DummyModule()
-sys.modules['multiprocessing'] = DummyModule()
-sys.modules['multiprocessing.context'] = DummyModule()
-sys.modules['multiprocessing.reduction'] = DummyModule()
-sys.modules['xml.sax.saxutils'] = DummyModule()
 
-sys.modules['tempfile'] = DummyModule()
-sys.modules['bz2'] = DummyModule()
-sys.modules['lzma'] = DummyModule()
-sys.modules['shutil'] = DummyModule()
-sys.modules['bisect'] = DummyModule()
-sys.modules['random'] = DummyModule()
-sys.modules['json'] = DummyModule()
-sys.modules['json.scanner'] = DummyModule()
-sys.modules['json.decoder'] = DummyModule()
-sys.modules['json.encoder'] = DummyModule()
-sys.modules['math'] = DummyModule()
-sys.modules['weakref'] = DummyModule()
+for _name in _STUBBED_MODULES:
+    _install_stub(_name)
 
 from androguard.core.dex import DEX
 import androguard.core.dex as androguard_dex


### PR DESCRIPTION
## What

Speeds up the query / scan / inflation layers. No API or output change.

- **code_item_scan**: match the opcode and the referenced idx high byte in one C-level regex pass,
  so Python only inspects surviving candidates; `bytes.translate` + bigint prefilter for dense
  opcode classes.
- **insn_locator**: flat bucket table and method-bound list; uleb128 decoding and the per-method
  bookkeeping inlined into the class_data walk; code-unit parity check before the instruction
  tokenizer.
- **apk_handler**: on-demand partial Deflate inflation for getclass, precise-class pre-flight,
  one-shot inflation, fork-based process pool.
- **decompiler**: startup stubs installed only for modules that are not already imported.
- **string_locator**: bulk-unpacked string id table.

## Measured

CI comparison (`python tests/benchmark_compare.py --baseline <dev-0.1.0 checkout> --samples 31`, paired,
both revisions on the same machine):

| metric | base | this PR | change |
|---|---:|---:|---:|
| `cli_findrefs` | 162.8 ms | **77.5 ms** | **-52.4%** |
| `unit/code_scan` | 22.8 ms | 3.5 ms | -84.8% |
| `unit/field_ref_scan` | 48.5 ms | 13.8 ms | -71.6% |
| `unit/method_ref_scan` | 36.3 ms | 11.2 ms | -69.2% |
| `unit/string_locator` | 6.6 ms | 4.2 ms | -36.8% |
| `unit/insn_locator` | 43.3 ms | 32.0 ms | -26.2% |
| `cli_getclass` | 62.6 ms | 59.4 ms | -5.1% |
| `unit/type_locator` / `unit/method_locator` / `unit/field_locator` | — | — | -0.6% / -0.2% / +0.0% |
| `core/decompile` | 35.2 ms | 35.6 ms | +1.1% |

All 11 gated metrics pass (`errors: []`).

## Verification

- `python tests/run_tests.py --require-decompiler --suite unit` — 20 tests OK
- `python tests/run_tests.py --require-decompiler --suite integration` — 4 tests OK
- `python tests/benchmark_compare.py --baseline <dev-0.1.0 checkout> --samples 31` — no gated regression
- CLI smoke on a real APK: `findrefs string/type/method/field/--fuzzy-class` and `getclass`
  (including the missing-class error path) all behave as before
- getclass decompiled output compared byte-for-byte against dev-0.1.0 (identical md5)
